### PR TITLE
update kickstart to include theme and silicon user

### DIFF
--- a/kickstart/css/styles.css
+++ b/kickstart/css/styles.css
@@ -1,0 +1,1102 @@
+:root {
+    --main-text-color: #424242;
+    --main-accent-color: #096324;
+    --input-background: #fbfbfb;
+    --body-background: #f7f7f7;
+    --tooltip-background: #e2e2e2;
+    --error-color: #ff0000;
+    --error-background: #ffe8e8;
+    --border-color: #dddddd;
+    --logo-url: url(https://fusionauth.io/assets/img/samplethemes/changebank/changebank.svg);
+    --font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  }
+  body {
+    font-family: var(--font-stack);
+    font-size: 16px;
+    color: var(--main-text-color);
+    background: var(--body-background);
+    line-height: normal;
+  }
+  .page-body:before {
+    content: '';
+    display: block;
+    width: 80%;
+    max-width: 20rem;
+    height: 3.5rem;
+    margin: 0 auto 3rem auto;
+    background-image: var(--logo-url);
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+  
+  /* Changes for Powered by FusionAuth div */
+  body > main main.page-body {
+    min-height: calc(100vh - 3rem); /* to make the Powered by FusionAuth div position at the bottom of the page if the page is shorter than the viewport */
+    padding-top: 3rem;
+  }
+  body > main {
+    padding-bottom: 2.5rem; /* giving Powered by FusionAuth more space */
+  }
+  #powered-by-fa {
+    position: absolute !important;
+  }
+  /* End Powered by FusionAuth */
+  
+  
+  /* Hiding help bar at top */
+  body > main {
+    padding-top: 0;
+  }
+  /* end help bar */
+  
+  
+  /* Typical typography */
+  h1, h2, h3, h4, h5, h6 {
+    line-height: normal;
+  }
+  p {
+    margin: 1.5em 0;
+    line-height: 1.375;
+  }
+  /* End typography */
+  
+  
+  /* Typical Buttons and Links */
+  a {
+    color: var(--main-accent-color);
+    text-decoration: underline;
+  }
+  a:hover {
+    color: var(--main-accent-color);
+    opacity: .8;
+  }
+  a:visited {
+    color: var(--main-accent-color);
+  }
+  .blue-text {
+    color: var(--main-accent-color) !important;
+  }
+  .form-row:last-of-type {
+    margin-bottom: 0;
+  }
+  .button {
+    font-size: 1.125rem !important;
+    border-radius: .5rem;
+    padding: 1rem !important;
+    line-height: normal !important;
+    letter-spacing: normal !important;
+  }
+  .button.blue {
+    background: var(--main-accent-color) !important;
+    width: 100%;
+    margin-top: 2.5rem;
+  }
+  .button.blue:hover {
+    opacity: .8 !important;
+    background: var(--main-accent-color) !important;
+  } 
+  .button.blue:focus {
+    background: var(--main-accent-color) !important;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.4),0 0 0 2px rgba(57,152,219,0.4);
+    outline: 1px solid #ffffff !important;
+  }
+  .button.blue > .fa {
+    display: none;
+  }
+  .secondary-btn,
+  main.page-body .row:last-of-type a {
+    text-decoration: none;
+    padding: .5em .75em;
+    border: 1px solid var(--main-accent-color);
+    border-radius: .25em;
+    font-size: .75rem;
+    margin-top: .7rem;
+    display: inline-block;
+    line-height: normal;
+  }
+  .button + a {
+    text-align: center;
+    display: block;
+    margin: 1em auto;
+  }
+  /* End buttons and links */
+  
+  
+  /* Typical Form panel and inputs */
+  .panel {
+    box-shadow: 0 0 1.5625rem 1.25rem rgba(234, 234, 234, 0.8);
+    border-radius: .625rem;
+    border: none;
+    padding: 2.25rem 2.75rem;
+  }
+  .panel h2,
+  fieldset legend,
+  legend {
+    text-align: center;
+    color: var(--main-accent-color);
+    font-size: 1.5625rem;
+    font-weight: 600;
+    margin: 0 0 2rem 0;
+    padding: 0;
+    border: none;
+  }
+  legend {
+    border: none;
+    width: auto;
+  }
+  form .form-row {
+    margin-bottom: 1.25rem;
+  }
+  label {
+    color: var(--main-text-color);
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  label.radio,
+  label.checkbox {
+    margin: 1rem 0;
+    font-weight: 400;
+  }
+  .input-addon-group, 
+  .input-addon-group > :last-child:not(.flat), 
+  .input-addon-group > .input:last-child:not(.flat), 
+  .input-addon-group > input:last-child:not(.flat) {
+    color: var(--main-text-color); /* overriding typical text color for inputs */
+  }
+  .input-addon-group span {
+    display: none; /* Hiding icons on inputs */
+  }
+  input::placeholder {
+    color: var(--main-text-color);
+  }
+  .input, 
+  input[type="email"], 
+  input[type="file"], 
+  input[type="number"], 
+  input[type="search"], 
+  input[type="text"], 
+  input[type="tel"], 
+  input[type="url"], 
+  input[type="password"], 
+  textarea, 
+  label.select select
+   {
+    background: var(--input-background);
+    border: 1px solid var(--border-color) !important;
+    border-radius: .25rem !important;
+    box-shadow: none;
+    font-size: 1rem;
+    padding: 1em .625em;
+  }
+  input:focus,
+  input:active,
+  textarea:focus,
+  textarea:active {
+    border: 1px solid #707070 !important;
+    box-shadow: none !important;
+  }
+  .radio input {
+    width: 1.3125rem;
+    height: 1.3125rem;
+  }
+  .radio span.box,
+  .checkbox span.box {
+    width: 1.3125rem;
+    height: 1.3125rem;
+    margin: 0;
+    border: solid 1px var(--border-color);
+    background-color: var(--input-background);
+  }
+  .radio span.box {
+    border-radius: 50%;
+  }
+  .radio input:checked + span.box {
+    border: 2px solid var(--main-accent-color);
+  }
+  .radio span.box::after {
+    box-shadow: none;
+    border-radius: 50%;
+    background: var(--main-accent-color);
+    width: .8125rem;
+    height: .8125rem;
+    top: .125rem;
+    left: .125rem;
+  }
+  .radio span.box:hover::after {
+    opacity: 0;
+  }
+  .radio span.label,
+  .checkbox span.label {
+    margin-left: .5rem;
+  }
+  .radio-items .form-row label span:last-of-type {
+    border-color: var(--border-color);
+  }
+  input[type="radio"] {
+    width: 1.3125rem;
+    height: 1.3125rem;
+    margin: 0;
+    border: solid 1px var(--border-color);
+    border-radius: 50%;
+    background-color: var(--input-background);
+    appearance: none;
+    -webkit-appearance: none;
+    vertical-align: text-bottom;
+  }
+  input[type="radio"]:focus,
+  input[type="radio"]:active,
+  input[type="radio"]:checked {
+    border: 2px solid var(--main-accent-color) !important;
+  }
+  input[type="radio"]:checked:after {
+    content: '';
+    box-shadow: none;
+    border-radius: 50%;
+    background: var(--main-accent-color);
+    width: .8125rem;
+    height: .8125rem;
+    top: .125rem;
+    left: .125rem;
+    position: absolute;
+  }
+  .checkbox span.box {
+    border-radius: .25rem;
+  }
+  .checkbox input:checked + span.box {
+    background: var(--main-accent-color);
+    border-color: var(--main-accent-color);
+  }
+  .checkbox span.box::after {
+    height: .25rem;
+    left: .25rem;
+    top: .3125rem;
+    transform: rotate(-46deg);
+    width: .625rem;
+    box-shadow: none;
+  }
+  .checkbox-list {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding-left: 0;
+  }
+  input[type="checkbox"] {
+    width: 1.3125rem;
+    height: 1.3125rem;
+    margin: 0;
+    border: solid 1px var(--border-color);
+    border-radius: .25rem;
+    background-color: var(--input-background);
+    appearance: none;
+    -webkit-appearance: none;
+    vertical-align: text-bottom;
+  }
+  input[type="checkbox"]:checked {
+    background-color: var(--main-accent-color);
+  }
+  input[type="checkbox"]:checked:after {
+    content: '';
+    background: transparent;
+    border: 2px solid #fff;
+    border-right: none;
+    border-top: none;
+    height: .25rem;
+    left: .25rem;
+    top: .3125rem;
+    transform: rotate(-46deg);
+    width: .625 rem;
+    display: block;
+    position: absolute;
+  }
+  label.select select {
+    color: var(--main-text-color);
+  }
+  label.select select option {
+    background: var(--input-background);
+    color: var(--main-text-color);
+  }
+  /* End Panel and Form Inputs */
+  
+  
+  /* Errors */
+  body .alert {
+    color: var(--main-text-color);
+  }
+  body .alert a {
+    height: auto;
+    width: auto;
+  }
+  body .alert.error a i.fa {
+    color: var(--error-color);
+  }
+  body .alert.error {
+    border: 1px solid var(--error-color);
+    margin: 0 0 2rem 0;
+    background: var(--error-background);
+    box-shadow: none;
+    border-radius: .25rem;
+  }
+  body .alert .dismiss-button i {
+    margin: 0;
+  }
+  .error {
+    font-size: .75rem;
+    margin: .5em 0;
+  }
+  label.error {
+    color: var(--error-color);
+    font-size: inherit;
+  }
+  form .form-row span.error {
+    color: var(--error-color);
+  }
+  input.error {
+    background: var(--error-background);
+    border-color: var(--error-color) !important;
+  }
+  /* End Errors */
+  
+  
+  /* Tooltip */
+  .tooltip {
+    background: var(--tooltip-background);
+    font-size: .75rem;
+    color: var(--main-text-color);
+    text-align: left;
+  }
+  .tooltip:after {
+    border-top-color: var(--tooltip-background);
+  }
+  .tooltip.inverted:before {
+    border-bottom-color: var(--tooltip-background);
+  }
+  .fa-info-circle {
+    color: var(--main-accent-color) !important;
+  }
+  /* End Tooltip */
+  
+  
+  table thead tr th {
+    color: var(--main-text-color);
+  }
+  table thead tr {
+    border-color: var(--border-color);
+  }
+  #locale-select {
+    width: 50%;
+    min-width: 10rem;
+  }
+  .grecaptcha-msg {
+    margin: 1rem 0;
+    text-align: left;
+  }
+  .progress-bar {
+    border-radius: .5rem;
+    border: 1px solid var(--border-color);
+    height: 1rem;
+  }
+  .progress-bar div {
+    border-radius: .5rem;
+    background: var(--main-accent-color);
+    height: 1rem;
+  }
+  hr, 
+  .hr-container hr {
+    border: none;
+    height: 1px;
+    background-color: #979797;
+  }
+  .hr-container div {
+    color: #959595;
+    font-size: .75rem;
+  }
+  .page-body > .row.center:last-of-type {
+    width: calc(100% - 30px);
+    margin: auto;
+    justify-content: space-between;
+  }
+  .page-body > .row.center:last-of-type > div {
+    width: 50%;
+    margin: 0;
+  }
+  @media only screen and (max-width: 450px) {
+    .page-body > .row.center:last-of-type {
+      flex-direction: column-reverse;
+      align-items: center;
+    }
+    .secondary-btn, main.page-body .row:last-of-type a {
+      margin-bottom: 1rem;
+    }
+    .page-body > .row.center:last-of-type > div {
+      text-align: center !important;
+    }
+  }
+  @media only screen and (min-width: 768px) {
+    .page-body > .row.center:last-of-type {
+      width: 33rem;
+    }
+  }
+  
+  /* Overriding existing grid per page */
+  #oauth-register .page-body > .row > .col-xs,
+  #oauth-register .page-body > .row > .col-sm-8,
+  #oauth-register .page-body > .row > .col-md-6,
+  #oauth-register .page-body > .row > .col-lg-5,
+  #oauth-register .page-body > .row > .col-xl-4,
+  #oauth-authorize .page-body > .row > .col-xs,
+  #oauth-authorize .page-body > .row > .col-sm-8,
+  #oauth-authorize .page-body > .row > .col-md-6,
+  #oauth-authorize .page-body > .row > .col-lg-5,
+  #oauth-authorize .page-body > .row > .col-xl-4,
+  #oauth-passwordless .page-body > .row > .col-xs,
+  #oauth-passwordless .page-body > .row > .col-sm-8,
+  #oauth-passwordless .page-body > .row > .col-md-6,
+  #oauth-passwordless .page-body > .row > .col-lg-5,
+  #oauth-passwordless .page-body > .row > .col-xl-4,
+  #oauth-two-factor .page-body > .row > .col-xs,
+  #oauth-two-factor .page-body > .row > .col-sm-8,
+  #oauth-two-factor .page-body > .row > .col-md-6,
+  #oauth-two-factor .page-body > .row > .col-lg-5,
+  #oauth-two-factor .page-body > .row > .col-xl-4,
+  #oauth-two-factor-methods .page-body > .row > .col-xs,
+  #oauth-two-factor-methods .page-body > .row > .col-sm-8,
+  #oauth-two-factor-methods .page-body > .row > .col-md-6,
+  #oauth-two-factor-methods .page-body > .row > .col-lg-5,
+  #oauth-two-factor-methods .page-body > .row > .col-xl-4,
+  #oauth-logout .page-body > .row > .col-xs,
+  #oauth-logout .page-body > .row > .col-sm-8,
+  #oauth-logout .page-body > .row > .col-md-6,
+  #oauth-logout .page-body > .row > .col-lg-5,
+  #oauth-logout .page-body > .row > .col-xl-4,
+  #oauth-device .page-body > .row > .col-xs,
+  #oauth-device .page-body > .row > .col-sm-8,
+  #oauth-device .page-body > .row > .col-md-6,
+  #oauth-device .page-body > .row > .col-lg-5,
+  #oauth-device .page-body > .row > .col-xl-4,
+  #oauth-device-complete .page-body > .row > .col-xs,
+  #oauth-device-complete .page-body > .row > .col-sm-8,
+  #oauth-device-complete .page-body > .row > .col-md-6,
+  #oauth-device-complete .page-body > .row > .col-lg-5,
+  #oauth-device-complete .page-body > .row > .col-xl-4,
+  #oauth-complete-reg .page-body > .row > .col-xs,
+  #oauth-complete-reg .page-body > .row > .col-sm-8,
+  #oauth-complete-reg .page-body > .row > .col-md-6,
+  #oauth-complete-reg .page-body > .row > .col-lg-5,
+  #oauth-complete-reg .page-body > .row > .col-xl-4, 
+  #oauth-child-reg .page-body > .row > .col-xs,
+  #oauth-child-reg .page-body > .row > .col-sm-8,
+  #oauth-child-reg .page-body > .row > .col-md-6,
+  #oauth-child-reg .page-body > .row > .col-lg-5,
+  #oauth-child-reg .page-body > .row > .col-xl-4,
+  #oauth-child-reg-complete .page-body > .row > .col-xs,
+  #oauth-child-reg-complete .page-body > .row > .col-sm-8,
+  #oauth-child-reg-complete .page-body > .row > .col-md-6,
+  #oauth-child-reg-complete .page-body > .row > .col-lg-5,
+  #oauth-child-reg-complete .page-body > .row > .col-xl-4, 
+  #oauth-not-registered .page-body > .row > .col-xs,
+  #oauth-not-registered .page-body > .row > .col-sm-8,
+  #oauth-not-registered .page-body > .row > .col-md-6,
+  #oauth-not-registered .page-body > .row > .col-lg-5,
+  #oauth-not-registered .page-body > .row > .col-xl-4, 
+  #oauth-error .page-body > .row > .col-xs,
+  #oauth-error .page-body > .row > .col-sm-8,
+  #oauth-error .page-body > .row > .col-md-6,
+  #oauth-error .page-body > .row > .col-lg-5,
+  #oauth-error .page-body > .row > .col-xl-4, 
+  #oauthstart-idp-link .page-body > .row > .col-xs,
+  #oauthstart-idp-link .page-body > .row > .col-sm-8,
+  #oauthstart-idp-link .page-body > .row > .col-md-6,
+  #oauthstart-idp-link .page-body > .row > .col-lg-5,
+  #oauthstart-idp-link .page-body > .row > .col-xl-4, 
+  #oauth-wait .page-body > .row > .col-xs,
+  #oauth-wait .page-body > .row > .col-sm-8,
+  #oauth-wait .page-body > .row > .col-md-6,
+  #oauth-wait .page-body > .row > .col-lg-5,
+  #oauth-wait .page-body > .row > .col-xl-4, 
+  #email-verification .page-body > .row > .col-xs,
+  #email-verification .page-body > .row > .col-sm-8,
+  #email-verification .page-body > .row > .col-md-6,
+  #email-verification .page-body > .row > .col-lg-5,
+  #email-verification .page-body > .row > .col-xl-4, 
+  #email-ver-required .page-body > .row > .col-xs,
+  #email-ver-required .page-body > .row > .col-sm-8,
+  #email-ver-required .page-body > .row > .col-md-6,
+  #email-ver-required .page-body > .row > .col-lg-5,
+  #email-ver-required .page-body > .row > .col-xl-4, 
+  #email-ver-complete .page-body > .row > .col-xs,
+  #email-ver-complete .page-body > .row > .col-sm-8,
+  #email-ver-complete .page-body > .row > .col-md-6,
+  #email-ver-complete .page-body > .row > .col-lg-5,
+  #email-ver-complete .page-body > .row > .col-xl-4, 
+  #email-ver-resent .page-body > .row > .col-xs,
+  #email-ver-resent .page-body > .row > .col-sm-8,
+  #email-ver-resent .page-body > .row > .col-md-6,
+  #email-ver-resent .page-body > .row > .col-lg-5,
+  #email-ver-resent .page-body > .row > .col-xl-4, 
+  #forgot-pwd .page-body > .row > .col-xs,
+  #forgot-pwd .page-body > .row > .col-sm-8,
+  #forgot-pwd .page-body > .row > .col-md-6,
+  #forgot-pwd .page-body > .row > .col-lg-5,
+  #forgot-pwd .page-body > .row > .col-xl-4,
+  #forgot-pwd-sent .page-body > .row > .col-xs,
+  #forgot-pwd-sent .page-body > .row > .col-sm-8,
+  #forgot-pwd-sent .page-body > .row > .col-md-6,
+  #forgot-pwd-sent .page-body > .row > .col-lg-5,
+  #forgot-pwd-sent .page-body > .row > .col-xl-4,
+  #verify-reg .page-body > .row > .col-xs,
+  #verify-reg .page-body > .row > .col-sm-8,
+  #verify-reg .page-body > .row > .col-md-6,
+  #verify-reg .page-body > .row > .col-lg-5,
+  #verify-reg .page-body > .row > .col-xl-4,
+  #verify-reg-complete .page-body > .row > .col-xs,
+  #verify-reg-complete .page-body > .row > .col-sm-8,
+  #verify-reg-complete .page-body > .row > .col-md-6,
+  #verify-reg-complete .page-body > .row > .col-lg-5,
+  #verify-reg-complete .page-body > .row > .col-xl-4,
+  #verify-reg-resent .page-body > .row > .col-xs,
+  #verify-reg-resent .page-body > .row > .col-sm-8,
+  #verify-reg-resent .page-body > .row > .col-md-6,
+  #verify-reg-resent .page-body > .row > .col-lg-5,
+  #verify-reg-resent .page-body > .row > .col-xl-4,
+  #verify-reg-required .page-body > .row > .col-xs,
+  #verify-reg-required .page-body > .row > .col-sm-8,
+  #verify-reg-required .page-body > .row > .col-md-6,
+  #verify-reg-required .page-body > .row > .col-lg-5,
+  #verify-reg-required .page-body > .row > .col-xl-4,
+  #acct-2fa-enable .page-body > .row > .col-xs-12,
+  #acct-2fa-enable .page-body > .row > .col-sm-12,
+  #acct-2fa-enable .page-body > .row > .col-md-10,
+  #acct-2fa-enable .page-body > .row > .col-lg-8, 
+  #acct-2fa-disable .page-body > .row > .col-xs-12,
+  #acct-2fa-disable .page-body > .row > .col-sm-12,
+  #acct-2fa-disable .page-body > .row > .col-md-10,
+  #acct-2fa-disable .page-body > .row > .col-lg-8,
+  #unauthorized-page .page-body > .row > .col-sm-10,
+  #unauthorized-page .page-body > .row > .col-md-8,
+  #unauthorized-page .page-body > .row > .col-lg-7,
+  #unauthorized-page .page-body > .row > .col-xl-5,
+  #change-pwd .page-body > .row > .col-xs,
+  #change-pwd .page-body > .row > .col-sm-8,
+  #change-pwd .page-body > .row > .col-md-6, 
+  #change-pwd .page-body > .row > .col-lg-5,
+  #change-pwd .page-body > .row > .col-xl-4,
+  #change-pwd-complete .page-body > .row > .col-xs,
+  #change-pwd-complete .page-body > .row > .col-sm-8,
+  #change-pwd-complete .page-body > .row > .col-md-6, 
+  #change-pwd-complete .page-body > .row > .col-lg-5,
+  #change-pwd-complete .page-body > .row > .col-xl-4 {
+    flex-basis: 33rem;
+    width: calc(100% - 30px);
+    max-width: 33rem;
+  }
+  @media only screen and (max-width: 575px) {
+    #oauth-register .page-body > .row > .col-xs,
+    #oauth-register .page-body > .row > .col-sm-8,
+    #oauth-register .page-body > .row > .col-md-6,
+    #oauth-register .page-body > .row > .col-lg-5,
+    #oauth-register .page-body > .row > .col-xl-4,
+    #oauth-authorize .page-body > .row > .col-xs,
+    #oauth-authorize .page-body > .row > .col-sm-8,
+    #oauth-authorize .page-body > .row > .col-md-6,
+    #oauth-authorize .page-body > .row > .col-lg-5,
+    #oauth-authorize .page-body > .row > .col-xl-4,
+    #oauth-passwordless .page-body > .row > .col-xs,
+    #oauth-passwordless .page-body > .row > .col-sm-8,
+    #oauth-passwordless .page-body > .row > .col-md-6,
+    #oauth-passwordless .page-body > .row > .col-lg-5,
+    #oauth-passwordless .page-body > .row > .col-xl-4,
+    #oauth-two-factor .page-body > .row > .col-xs,
+    #oauth-two-factor .page-body > .row > .col-sm-8,
+    #oauth-two-factor .page-body > .row > .col-md-6,
+    #oauth-two-factor .page-body > .row > .col-lg-5,
+    #oauth-two-factor .page-body > .row > .col-xl-4,
+    #oauth-two-factor-methods .page-body > .row > .col-xs,
+    #oauth-two-factor-methods .page-body > .row > .col-sm-8,
+    #oauth-two-factor-methods .page-body > .row > .col-md-6,
+    #oauth-two-factor-methods .page-body > .row > .col-lg-5,
+    #oauth-two-factor-methods .page-body > .row > .col-xl-4,
+    #oauth-logout .page-body > .row > .col-xs,
+    #oauth-logout .page-body > .row > .col-sm-8,
+    #oauth-logout .page-body > .row > .col-md-6,
+    #oauth-logout .page-body > .row > .col-lg-5,
+    #oauth-logout .page-body > .row > .col-xl-4,
+    #oauth-device .page-body > .row > .col-xs,
+    #oauth-device .page-body > .row > .col-sm-8,
+    #oauth-device .page-body > .row > .col-md-6,
+    #oauth-device .page-body > .row > .col-lg-5,
+    #oauth-device .page-body > .row > .col-xl-4,
+    #oauth-device-complete .page-body > .row > .col-xs,
+    #oauth-device-complete .page-body > .row > .col-sm-8,
+    #oauth-device-complete .page-body > .row > .col-md-6,
+    #oauth-device-complete .page-body > .row > .col-lg-5,
+    #oauth-device-complete .page-body > .row > .col-xl-4,
+    #oauth-complete-reg .page-body > .row > .col-xs,
+    #oauth-complete-reg .page-body > .row > .col-sm-8,
+    #oauth-complete-reg .page-body > .row > .col-md-6,
+    #oauth-complete-reg .page-body > .row > .col-lg-5,
+    #oauth-complete-reg .page-body > .row > .col-xl-4, 
+    #oauth-child-reg .page-body > .row > .col-xs,
+    #oauth-child-reg .page-body > .row > .col-sm-8,
+    #oauth-child-reg .page-body > .row > .col-md-6,
+    #oauth-child-reg .page-body > .row > .col-lg-5,
+    #oauth-child-reg .page-body > .row > .col-xl-4,
+    #oauth-child-reg-complete .page-body > .row > .col-xs,
+    #oauth-child-reg-complete .page-body > .row > .col-sm-8,
+    #oauth-child-reg-complete .page-body > .row > .col-md-6,
+    #oauth-child-reg-complete .page-body > .row > .col-lg-5,
+    #oauth-child-reg-complete .page-body > .row > .col-xl-4, 
+    #oauth-not-registered .page-body > .row > .col-xs,
+    #oauth-not-registered .page-body > .row > .col-sm-8,
+    #oauth-not-registered .page-body > .row > .col-md-6,
+    #oauth-not-registered .page-body > .row > .col-lg-5,
+    #oauth-not-registered .page-body > .row > .col-xl-4, 
+    #oauth-error .page-body > .row > .col-xs,
+    #oauth-error .page-body > .row > .col-sm-8,
+    #oauth-error .page-body > .row > .col-md-6,
+    #oauth-error .page-body > .row > .col-lg-5,
+    #oauth-error .page-body > .row > .col-xl-4, 
+    #oauthstart-idp-link .page-body > .row > .col-xs,
+    #oauthstart-idp-link .page-body > .row > .col-sm-8,
+    #oauthstart-idp-link .page-body > .row > .col-md-6,
+    #oauthstart-idp-link .page-body > .row > .col-lg-5,
+    #oauthstart-idp-link .page-body > .row > .col-xl-4,
+    #oauth-wait .page-body > .row > .col-xs,
+    #oauth-wait .page-body > .row > .col-sm-8,
+    #oauth-wait .page-body > .row > .col-md-6,
+    #oauth-wait .page-body > .row > .col-lg-5,
+    #oauth-wait .page-body > .row > .col-xl-4, 
+    #email-verification .page-body > .row > .col-xs,
+    #email-verification .page-body > .row > .col-sm-8,
+    #email-verification .page-body > .row > .col-md-6,
+    #email-verification .page-body > .row > .col-lg-5,
+    #email-verification .page-body > .row > .col-xl-4, 
+    #email-ver-required .page-body > .row > .col-xs,
+    #email-ver-required .page-body > .row > .col-sm-8,
+    #email-ver-required .page-body > .row > .col-md-6,
+    #email-ver-required .page-body > .row > .col-lg-5,
+    #email-ver-required .page-body > .row > .col-xl-4, 
+    #email-ver-complete .page-body > .row > .col-xs,
+    #email-ver-complete .page-body > .row > .col-sm-8,
+    #email-ver-complete .page-body > .row > .col-md-6,
+    #email-ver-complete .page-body > .row > .col-lg-5,
+    #email-ver-complete .page-body > .row > .col-xl-4, 
+    #email-ver-resent .page-body > .row > .col-xs,
+    #email-ver-resent .page-body > .row > .col-sm-8,
+    #email-ver-resent .page-body > .row > .col-md-6,
+    #email-ver-resent .page-body > .row > .col-lg-5,
+    #email-ver-resent .page-body > .row > .col-xl-4, 
+    #forgot-pwd .page-body > .row > .col-xs,
+    #forgot-pwd .page-body > .row > .col-sm-8,
+    #forgot-pwd .page-body > .row > .col-md-6,
+    #forgot-pwd .page-body > .row > .col-lg-5,
+    #forgot-pwd .page-body > .row > .col-xl-4,
+    #forgot-pwd-sent .page-body > .row > .col-xs,
+    #forgot-pwd-sent .page-body > .row > .col-sm-8,
+    #forgot-pwd-sent .page-body > .row > .col-md-6,
+    #forgot-pwd-sent .page-body > .row > .col-lg-5,
+    #forgot-pwd-sent .page-body > .row > .col-xl-4,
+    #verify-reg .page-body > .row > .col-xs,
+    #verify-reg .page-body > .row > .col-sm-8,
+    #verify-reg .page-body > .row > .col-md-6,
+    #verify-reg .page-body > .row > .col-lg-5,
+    #verify-reg .page-body > .row > .col-xl-4,
+    #verify-reg-complete .page-body > .row > .col-xs,
+    #verify-reg-complete .page-body > .row > .col-sm-8,
+    #verify-reg-complete .page-body > .row > .col-md-6,
+    #verify-reg-complete .page-body > .row > .col-lg-5,
+    #verify-reg-complete .page-body > .row > .col-xl-4,
+    #verify-reg-resent .page-body > .row > .col-xs,
+    #verify-reg-resent .page-body > .row > .col-sm-8,
+    #verify-reg-resent .page-body > .row > .col-md-6,
+    #verify-reg-resent .page-body > .row > .col-lg-5,
+    #verify-reg-resent .page-body > .row > .col-xl-4,
+    #verify-reg-required .page-body > .row > .col-xs,
+    #verify-reg-required .page-body > .row > .col-sm-8,
+    #verify-reg-required .page-body > .row > .col-md-6,
+    #verify-reg-required .page-body > .row > .col-lg-5,
+    #verify-reg-required .page-body > .row > .col-xl-4,
+    #acct-2fa-enable .page-body > .row > .col-xs-12,
+    #acct-2fa-enable .page-body > .row > .col-sm-12,
+    #acct-2fa-enable .page-body > .row > .col-md-10,
+    #acct-2fa-enable .page-body > .row > .col-lg-8,
+    #acct-2fa-disable .page-body > .row > .col-xs-12,
+    #acct-2fa-disable .page-body > .row > .col-sm-12,
+    #acct-2fa-disable .page-body > .row > .col-md-10,
+    #acct-2fa-disable .page-body > .row > .col-lg-8,
+    #unauthorized-page .page-body > .row > .col-sm-10,
+    #unauthorized-page .page-body > .row > .col-md-8,
+    #unauthorized-page .page-body > .row > .col-lg-7,
+    #unauthorized-page .page-body > .row > .col-xl-5,
+    #change-pwd .page-body > .row > .col-xs,
+    #change-pwd .page-body > .row > .col-sm-8,
+    #change-pwd .page-body > .row > .col-md-6, 
+    #change-pwd .page-body > .row > .col-lg-5,
+    #change-pwd .page-body > .row > .col-xl-4,
+    #change-pwd-complete .page-body > .row > .col-xs,
+    #change-pwd-complete .page-body > .row > .col-sm-8,
+    #change-pwd-complete .page-body > .row > .col-md-6, 
+    #change-pwd-complete .page-body > .row > .col-lg-5,
+    #change-pwd-complete .page-body > .row > .col-xl-4  {
+      flex-basis: calc(100% - 30px);
+      width: calc(100% - 30px);
+      max-width: 33rem;
+    }
+    .panel {
+      padding-left: .5rem;
+      padding-right: .5rem;
+    }
+  }
+  @media only screen and (min-width: 768px) {
+    #acct-2fa-index .page-body > .row.center:last-of-type {
+      width: calc(83.33333333% - 30px);
+    }
+  }
+  @media only screen and (min-width: 992px) {
+    #acct-2fa-index .page-body > .row > .col-xs12,
+    #acct-2fa-index .page-body > .row > .col-sm-12,
+    #acct-2fa-index .page-body > .row > .col-md-10,
+    #acct-2fa-index .page-body > .row > .col-lg-8 {
+      flex-basis: 54.125rem;
+      max-width: 54.125rem;
+    } 
+    #acct-2fa-index .page-body > .row.center:last-of-type {
+      width: 54.125rem;
+    }
+  }
+  /* End grid override */
+  
+  
+  /* Cleaning up spacing */
+  #verify-reg-required .link.blue-text,
+  #verify-reg-required .grecaptcha-msg,
+  #verify-reg-required .panel > main > .full fieldset,
+  #verify-reg .grecaptcha-msg,
+  #verify-reg .panel > main > .full fieldset,
+  #email-ver-required .grecaptcha-msg,
+  #email-verification .grecaptcha-msg,
+  #email-ver-required fieldset,
+  #email-ver-required .panel > main > #verification-required-resend-code fieldset,
+  #oauth-two-factor .panel .full > fieldset,
+  #oauth-two-factor .panel > main > fieldset + .form-row,
+  #oauth-two-factor-methods .full,
+  #oauth-two-factor-methods .blue.button,
+  #oauth-authorize .panel > main > form > .form-row:first-of-type,
+  #oauth-passwordless .panel > main > .full > .form-row:first-of-type, 
+  #oauth-register .panel > main > .full > .form-row:first-of-type,
+  #forgot-pwd .panel > main > .full fieldset,
+  #forgot-pwd .panel .grecaptcha-msg, 
+  #change-pwd .panel > main .full > .form-row:first-of-type,
+  #acct-2fa-index .panel > main > fieldset {
+    margin-bottom: 0;
+  }
+  /* End spacing */
+  
+  
+  /* Other page specific styles */
+  
+  #acct-2fa-index .blue.button {
+    max-width: 25rem;
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+  }
+  #acct-2fa-index table {
+    margin-bottom: 3rem;
+  }
+  #acct-2fa-enable .d-flex {
+    display: block;
+  }
+  #acct-2fa-enable #qrcode {
+    padding-left: 0;
+  }
+  #acct-2fa-enable #qrcode img {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  #acct-2fa-disable main > fieldset {
+    margin: 0;
+  }
+  #oauth-two-factor .panel form > .form-row:last-of-type a .fa {
+    display: none; /* hiding icon in button */
+  }
+  #oauth-two-factor .panel > main > fieldset .form-row.mt-4 {
+    margin-top: 0;
+  }
+  #oauth-two-factor-methods input[type="radio"] {
+    vertical-align: text-top;
+  }
+  #oauth-two-factor-methods .full fieldset {
+    margin-top: 2rem;
+    margin-bottom: 0;
+  }
+  #oauth-two-factor-methods .full fieldset .form-row:last-child label {
+    padding-bottom: 0;
+  }
+  #oauth-two-factor-methods .radio-items .form-row label span:last-of-type {
+    margin-left: 1.875rem;
+  }
+  #oauth-device .push-top {
+    margin-top: 0;
+  }
+  #oauth-device #device-form > p {
+    text-align: center;
+  }
+  #oauth-device #user_code_container input[type="text"] {
+    color: var(--main-text-color);
+  }
+  #index-page ul li a {
+    font-family: var(--font-stack);
+  }
+  #oauth-passwordless .panel form .form-row:last-of-type p,
+  #oauth-register .panel form .form-row:last-of-type p,
+  #oauth-two-factor .panel form > .form-row:last-of-type,
+  #forgot-pwd .panel form > .form-row:last-of-type p,
+  #forgot-pwd-sent .panel main p:last-of-type,
+  #oauth-wait .panel main p:last-of-type {
+    margin-bottom: 0;
+    text-align: center;
+  }
+  
+  /* Account Index page */
+  #acct-index .panel > main {
+    padding: 0;
+  }
+  #acct-index .user-details.mb-5 {
+    margin-bottom: 0;
+  }
+  #acct-index #edit-profile span {
+    font-size: inherit !important;
+  }
+  #acct-index #edit-profile span:after {
+    content: 'Edit';
+    margin-left: .25em;
+  }
+  #acct-index .user-details > div {
+    margin: 0;
+    width: 100%;
+    max-width: 100%;
+    flex-basis: 100%;
+  }
+  #acct-index .user-details dl {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin: 1.25rem 0;
+  }
+  #acct-index .user-details dt {
+    float: none;
+    font-weight: 500;
+    width: 40%;
+    margin: 0;
+  }
+  #acct-index .user-details dd {
+    width: 60%;
+    margin: 0;
+  }
+  #acct-index .panel {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+  #acct-index .panel:before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4rem;
+    background-color: var(--main-accent-color);
+    border-radius: .625rem .625rem 0 0;
+  }
+  #acct-index .user-details .avatar > div:last-of-type {
+    color: var(--main-accent-color);
+    font-weight: 500;
+    font-size: 1.5rem;
+  }
+  #acct-index .user-details .avatar {
+    top: -2.25rem;
+    position: relative;
+    z-index: 2;
+    padding: 0;
+  }
+  #acct-index .user-details .avatar > div:first-of-type {
+    max-width: 7.5rem;
+    padding: 0;
+  }
+  #acct-index .user-details .avatar > div:first-of-type img {
+    border: .625rem solid #ffffff;
+  }
+  #acct-index .user-details > div:nth-of-type(2) > div {
+    padding: 0;
+  }
+  #acct-index .user-details > div:nth-of-type(2) > div > div {
+    margin: 0;
+    flex-basis: 100%;
+    width: 100%;
+    max-width: 100%;
+  }
+  #acct-index .user-details .panel-actions {
+    top: 3.5rem;
+    right: .25rem;
+  }
+  @media only screen and (max-width: 450px) {
+    #acct-index .user-details dl {
+      flex-direction: column;
+    }
+    #acct-index .user-details dt,
+    #acct-index .user-details dd {
+      width: 100%;
+      margin-bottom: .5em;
+    }
+  }
+  @media only screen and (min-width: 768px) {
+    #acct-index .panel:before {
+      width: 4rem;
+      height: 100%;
+      border-radius: .625rem 0 0 .625rem;
+    }
+    #acct-index .user-details {
+      display: block;
+      margin-left: 8rem;
+    }
+    #acct-index .user-details > div {
+      margin: 0;
+      width: 80%;
+      max-width: 80%;
+    }
+    #acct-index .user-details .avatar {
+      position: static;
+    }
+    #acct-index .user-details .avatar > div:first-of-type {
+      position: absolute;
+      left: .75rem;
+      top: calc(50% - 3.25rem);
+      width: 6.5rem;
+    }
+    #acct-index .user-details .avatar > div:first-of-type img {
+      border-width: .5rem;
+    }
+    #acct-index .user-details .avatar > div:last-of-type {
+      text-align: left;
+    }
+    #acct-index .user-details .panel-actions {
+      top: -0.25rem;
+      right: .5rem;
+    }
+    #acct-index .page-body > .row.center:last-of-type {
+      width: calc(83.33333333% - 30px);
+    }
+  }
+  @media only screen and (min-width: 992px) {
+    #acct-index .page-body > .row:first-of-type > .col-xs-12,
+    #acct-index .page-body > .row:first-of-type > .col-sm-12,
+    #acct-index .page-body > .row:first-of-type > .col-md-10,
+    #acct-index .page-body > .row:first-of-type > .col-lg-8 {
+      flex-basis: 54.125rem;
+      max-width: 54.125rem;
+    } 
+    #acct-index .page-body > .row.center:last-of-type {
+      width: 54.125rem;
+    } 
+    #acct-index .panel:before {
+      width: 6.25rem;
+    }
+    #acct-index .user-details {
+      margin-left: 13rem;
+    }
+    #acct-index .user-details .panel-actions {
+      padding: 0;
+      top: 2.25rem;
+      right: 2.25rem;
+    }
+    #acct-index .user-details .panel-actions .status,
+    #acct-index .user-details .panel-actions #edit-profile {
+      margin: 0;
+    }
+    #acct-index .user-details > div:first-of-type {
+      border: none;
+      width: auto;
+      flex-basis: auto;
+    }
+    #acct-index .user-details .avatar {
+      left: -.25rem;
+    }
+    #acct-index .user-details .avatar > div:first-of-type {
+      width: 8.75rem;
+      max-width: 8.75rem;
+      top: calc(50% - 4.5rem);
+      left: 1.875rem;
+    }
+    #acct-index .user-details .avatar > div:first-of-type img {
+      border-width: .75rem;
+    }
+  }
+  /*End Account Index page */
+  
+  
+  /* specific page button/link overrides */
+  #acct-2fa-enable .gray.button {
+    color: var(--main-accent-color) !important;
+    padding: .5em .75em !important;
+    border: 1px solid var(--main-accent-color) !important;
+    border-radius: .25em;
+    font-size: .75rem !important;
+    margin: 1rem auto;
+    display: block;
+    line-height: normal !important;
+    background: transparent !important;
+  }
+  #email-ver-required .link.blue-text {
+    display: block;
+    margin: 1rem auto;
+    text-decoration: underline;
+  }
+  #oauth-two-factor .panel form > .form-row:last-of-type a,
+  #verify-reg-required .panel .link.blue-text {
+    display: block;
+    margin: 1rem auto 0 auto;
+    text-decoration: underline;
+  }
+  #email-ver-required .link.blue-text .fa,
+  #verify-reg-required .panel .link.blue-text .fa {
+    display: none; /* hiding icon in link */
+  }
+  #oauth-passwordless .panel form .form-row:last-of-type a,
+  #oauth-register .panel form .form-row:last-of-type a,
+  #forgot-pwd .panel form > .form-row:last-of-type a,
+  #forgot-pwd-sent .panel main p:last-of-type a,
+  #oauth-wait .panel main p:last-of-type a {
+    color: var(--main-accent-color) !important;
+    padding: .5em .75em;
+    border: 1px solid var(--main-accent-color) !important;
+    border-radius: .25em;
+    font-size: .75rem;
+    margin: 1rem auto 0 auto;
+    display: inline-block;
+    line-height: normal;
+    text-decoration: none;
+  }
+  #forgot-pwd-sent .panel main p:last-of-type a {
+    color: var(--main-accent-color) !important;
+    padding: .5em .75em;
+    border: 1px solid var(--main-accent-color) !important;
+    border-radius: .25em;
+    font-size: .75rem;
+    margin: 0 auto;
+    display: inline-block;
+    line-height: normal;
+    text-decoration: none;
+  }
+  #oauthstart-idp-link .blue.button {
+    height: auto !important;
+    margin-top: 0;
+  }
+  #oauthstart-idp-link .panel main div:last-of-type a {
+    display: block;
+    border: none;
+    margin-top: 0;
+    padding: 0;
+  }
+  /* End page specific buttons and links */
+  

--- a/kickstart/kickstart.json
+++ b/kickstart/kickstart.json
@@ -1,15 +1,16 @@
 {
     "variables": {
-        "applicationId": "E9FDB985-9173-4E01-9D73-AC2D60D1DC8E",
-        "apiKey": "this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works_dont_use_this_in_prod",
+        "apiKey": "33052c8a-c283-4e96-9d2a-eb1215c69f8f-not-for-prod",
         "asymmetricKeyId": "#{UUID()}",
-        "clientSecret": "this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works_dont_use_this_in_prod",
+        "applicationId": "c2aeeb1e-65cd-43c5-9326-02dce5e03705",
+        "clientSecret": "2HYT86lWSAntc-mvtHLX5XXEpk9ThcqZb4YEh65CLjA-not-for-prod",
+        "newThemeId": "#{UUID()}",
         "defaultTenantId": "d7d09513-a3f5-401c-9685-34ab6c552453",
-        "adminEmail": "admin@fusionauthexample.com",
-        "adminPassword": "adminpassword",
+        "adminEmail": "admin@example.com",
+        "adminPassword": "password",
         "adminUserId": "00000000-0000-0000-0000-000000000001",
-        "userEmail": "user@fusionauthexample.com",
-        "userPassword": "userpassword",
+        "userEmail": "richard@example.com",
+        "userPassword": "password",
         "userUserId":  "00000000-0000-0000-0000-111111111111"
     },
     "apiKeys": [
@@ -40,7 +41,7 @@
                 "name": "ExampleNodeApp",
                 "oauthConfiguration" : {
                     "authorizedRedirectURLs": ["http://localhost:3000/oauth-callback"],
-                    "logoutURL": "http://localhost:4200/",
+                    "logoutURL": "http://localhost:3000/",
                     "clientSecret": "#{clientSecret}",
                     "enabledGrants": ["authorization_code", "refresh_token"]
                 },
@@ -91,6 +92,34 @@
                         "favoriteColor": "turquoise"
                     }
                 }
+            }
+        },
+        {
+            "method": "POST",
+            "url": "/api/theme/#{newThemeId}",
+            "body": {
+                "sourceThemeId": "75a068fd-e94b-451a-9aeb-3ddb9a3b5987",
+                "theme": {
+                    "name": "React theme"
+                } 
+            }
+        },
+        {
+            "method": "PATCH",
+            "url": "/api/theme/#{newThemeId}",
+            "body": {
+                "theme": {
+                    "stylesheet": "@{css/styles.css}"
+                } 
+            }
+        },
+        {
+            "method": "PATCH",
+            "url": "/api/tenant/#{defaultTenantId}",
+            "body": {
+                "tenant": {
+                    "themeId": "#{newThemeId}"
+                } 
             }
         }
     ]


### PR DESCRIPTION
I think we should all probably review and agree on what this looks like, but it is a start. 

Each app still needs specific updates based on that app, for instance in the Next.js I still used the HTML/CSS from the template but had to move them into something like `app/src/page.tsx`. But it keeps a nice look and feel with the theme for the login within FusionAuth.